### PR TITLE
ignore -X parameter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,8 @@ pub fn parse_to_strings(input: &str) -> Result<Vec<String>, VcardError> {
 
     let input = Regex::new(r"(?mi)^\s*(BEGIN|END):VCARD\s*?$").unwrap().replace_all(input, "$1:VCARD");
     let input = Regex::new(r"(?mi)\n\s").unwrap().replace_all(&*input, "");
-
+    let input = Regex::new(r"(?mi)^X-.*\n").unwrap().replace_all(&*input, "");
+    
     let regex = Regex::new(r"(?mi)\s*?BEGIN:VCARD\s*?$\n([\s\S]*?)\s*?END:VCARD\s*?$\n?").unwrap();
     for cap in regex.captures_iter(&*input) {
         data.push(cap[1].to_string())


### PR DESCRIPTION
delete lines starting with -X in the input of parse_to_strings to ignore "X-" parameter and be compliant with https://www.rfc-editor.org/rfc/rfc6350#section-5