### PR TITLE
Derive Debug for Vcard and dependencies

### DIFF
--- a/src/vcard/mod.rs
+++ b/src/vcard/mod.rs
@@ -24,7 +24,7 @@ pub const REQUIRED: [PropertyType; 2] = [PropertyType::Version, PropertyType::Fn
 /// List of properties that can only be represented once in a vCard.
 pub const SINGLE: [PropertyType; 11] = [PropertyType::Anniversary, PropertyType::BDay, PropertyType::BirthPlace, PropertyType::DeathDate, PropertyType::DeathPlace, PropertyType::Gender, PropertyType::Kind, PropertyType::N, PropertyType::ProdId, PropertyType::Rev, PropertyType::Uid];
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 /// The main vCard object. It is a collection of properties that follow the RFC 6350 vCard specification.
 ///
 /// A vCard can be created individually using [Vcard::default](Vcard::default), [Vcard::try_from](Vcard::try_from<&str>()) and [Vcard::from](Vcard::from) or as an array of vCard objects

--- a/src/vcard/mod.rs
+++ b/src/vcard/mod.rs
@@ -24,7 +24,7 @@ pub const REQUIRED: [PropertyType; 2] = [PropertyType::Version, PropertyType::Fn
 /// List of properties that can only be represented once in a vCard.
 pub const SINGLE: [PropertyType; 11] = [PropertyType::Anniversary, PropertyType::BDay, PropertyType::BirthPlace, PropertyType::DeathDate, PropertyType::DeathPlace, PropertyType::Gender, PropertyType::Kind, PropertyType::N, PropertyType::ProdId, PropertyType::Rev, PropertyType::Uid];
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 /// The main vCard object. It is a collection of properties that follow the RFC 6350 vCard specification.
 ///
 /// A vCard can be created individually using [Vcard::default](Vcard::default), [Vcard::try_from](Vcard::try_from<&str>()) and [Vcard::from](Vcard::from) or as an array of vCard objects

--- a/src/vcard/parameter/mod.rs
+++ b/src/vcard/parameter/mod.rs
@@ -63,7 +63,7 @@ pub mod types;
 /// let parameter = Parameter::try_from((&PropertyType::Tel, "TYPE=WORK")).expect("Unable to parse parameter.");
 /// assert_eq!(parameter.to_string(), "TYPE=WORK");
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Parameter {
     parameter_type: ParameterType,
     parameter_value: Value,

--- a/src/vcard/parameter/types.rs
+++ b/src/vcard/parameter/types.rs
@@ -20,7 +20,7 @@ pub const PARAMETER_TYPE_TZ: &str = "TZ";
 pub const PARAMETER_TYPE_VALUE: &str = "VALUE";
 
 /// A list of parameter types. See [RFC 6350 Section 5](https://datatracker.ietf.org/doc/html/rfc6350#section-5).
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ParameterType {
     AltId,
     Any,

--- a/src/vcard/property/mod.rs
+++ b/src/vcard/property/mod.rs
@@ -25,7 +25,7 @@ pub mod types;
 /// let property = Property::from(PropertyType::Version);
 /// assert_eq!(property.to_string(), "VERSION:4.0");
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Property {
     uuid: Uuid,
     property_type: PropertyType,

--- a/src/vcard/property/types.rs
+++ b/src/vcard/property/types.rs
@@ -48,7 +48,7 @@ pub const PROPERTY_TYPE_VERSION: &str = "VERSION";
 pub const PROPERTY_TYPE_XML: &str = "XML";
 
 /// A list of property types.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PropertyType {
     Adr,
     Anniversary,

--- a/src/vcard/values/data.rs
+++ b/src/vcard/values/data.rs
@@ -58,7 +58,7 @@ use crate::VcardError;
 ///
 /// let data = ValueData::TextList(vec![String::from("Work"), String::from("Work")]);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ValueData {
     /// Represents a boolean value, see [RFC 6350 4.4](https://datatracker.ietf.org/doc/html/rfc6350#section-4.4).
     Boolean(bool),

--- a/src/vcard/values/mod.rs
+++ b/src/vcard/values/mod.rs
@@ -16,7 +16,7 @@ pub mod data;
 pub mod kind;
 
 /// Stores value data for both properties and parameters.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Value {
     data: ValueData,
 }


### PR DESCRIPTION
When I'm working with a parser I like to print sample data so I can see how it's working and figure out how to use it. That was pretty hard without Debug implemented.