### PR TITLE
feat: implement std::error::Error for VcardError:

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types and handling.
 
 use std::fmt::{Display, Formatter};
-
+use std::error::Error;
 use nom::error::{ContextError, ErrorKind, ParseError};
 
 #[derive(Debug, Eq, PartialEq)]
@@ -113,3 +113,5 @@ impl Display for VcardError {
         }
     }
 }
+
+impl Error for VcardError {}


### PR DESCRIPTION
First, a big thank you for rewriting this splendid library !

I want to make this very small contribution.

Default implementation of [std::error::Error](https://doc.rust-lang.org/stable/std/error/trait.Error.html) for [VcardError](https://docs.rs/vcard_parser/latest/vcard_parser/error/enum.VcardError.html). Allow the use of the operator '?' to propagate the error of this crate in a more generic way.

For example, this code would compile with this patch.

```rust
use std::error::Error;
use vcard_parser::parse_vcards;

fn main() -> Result<(), Box<dyn Error>> {
    parse_vcards("")?;
    Ok(())
}

```

Without this patch, the compilation fails:

```rust
 --> src/main.rs:5:21
  |
5 |     parse_vcards("")?;
  |                     ^ the trait `std::error::Error` is not implemented for `VcardError`
  |
  = help: the following other types implement trait `FromResidual<R>`:
            <Result<T, F> as FromResidual<Result<Infallible, E>>>
            <Result<T, F> as FromResidual<Yeet<E>>>
  = note: required for `Box<dyn std::error::Error>` to implement `From<VcardError>`
  = note: required for `Result<(), Box<dyn std::error::Error>>` to implement `FromResidual<Result<Infallible, VcardError>>`

For more information about this error, try `rustc --explain E0277`.
```